### PR TITLE
Hide copyright footer on ProblemBuilder XBlock

### DIFF
--- a/cme/lms/static/sass/_overrides.scss
+++ b/cme/lms/static/sass/_overrides.scss
@@ -395,4 +395,9 @@ ul li, ol li {
     margin-bottom: 25px;
 }
 
+// Hide the copyright footer on the ProblemBuilder XBlock
+.xblock .mentoring .copyright {
+    display: none;
+}
+
 @import '_mobile.scss';

--- a/lagunita/lms/static/sass/_overrides.scss
+++ b/lagunita/lms/static/sass/_overrides.scss
@@ -480,4 +480,9 @@ ul li, ol li {
     margin-bottom: 25px;
 }
 
+// Hide the copyright footer on the ProblemBuilder XBlock
+.xblock .mentoring .copyright {
+    display: none;
+}
+
 @import '_mobile.scss';

--- a/scpd/lms/static/sass/_overrides.scss
+++ b/scpd/lms/static/sass/_overrides.scss
@@ -30,3 +30,8 @@
         }
     }
 }
+
+// Hide the copyright footer on the ProblemBuilder XBlock
+.xblock .mentoring .copyright {
+    display: none;
+}

--- a/suclass/lms/static/sass/_overrides.scss
+++ b/suclass/lms/static/sass/_overrides.scss
@@ -410,4 +410,9 @@ ul li, ol li {
     margin-bottom: 25px;
 }
 
+// Hide the copyright footer on the ProblemBuilder XBlock
+.xblock .mentoring .copyright {
+    display: none;
+}
+
 @import '_mobile.scss';


### PR DESCRIPTION
We've reached out to OpenCraft in hopes of making this configurable, if
not the default, upstream [1]. Until then, we can override via our
theme.

[1] https://github.com/open-craft/problem-builder/issues/182