### PR TITLE
Don't force a height on slick-grid cells

### DIFF
--- a/lagunita/lms/static/sass/partials/base/custom_overrides/_instructor.scss
+++ b/lagunita/lms/static/sass/partials/base/custom_overrides/_instructor.scss
@@ -2,8 +2,10 @@
     .slickgrid {
         .slick-header-column.ui-state-default,
         .slick-row > .slick-cell {
-            height: 30px;
             padding: 5px;
+        }
+        .slick-header-column.ui-state-default {
+            height: 30px;
         }
     }
 }


### PR DESCRIPTION
slick-cells should be allowed to be as big as they need to be...

Original bug reported:
![image](https://user-images.githubusercontent.com/3364609/42716243-706ab432-86af-11e8-9617-93f287cc6847.png)

After the previous fix (it turns out other tables also use the same code):
![screen shot 2018-07-13 at 3 13 11 pm](https://user-images.githubusercontent.com/3364609/42716218-56246ee2-86af-11e8-8291-681f8336c0f7.png)

Finally, after applying this PR:
![screen shot 2018-07-13 at 1 53 17 pm](https://user-images.githubusercontent.com/3364609/42713397-352b0ea4-86a4-11e8-8236-0dbeb9456881.png)
