### PR TITLE
Make instructor table fit two rows of links

### DIFF
--- a/lagunita/lms/static/sass/partials/base/custom_overrides/_instructor.scss
+++ b/lagunita/lms/static/sass/partials/base/custom_overrides/_instructor.scss
@@ -2,7 +2,7 @@
     .slickgrid {
         .slick-header-column.ui-state-default,
         .slick-row > .slick-cell {
-            padding: 5px;
+            height: 100%;
         }
         .slick-header-column.ui-state-default {
             height: 30px;


### PR DESCRIPTION
@stvstnfrd & @Stanford-Online/openedx-courseops 

![screen shot 2018-08-16 at 12 19 17 pm](https://user-images.githubusercontent.com/3364609/44230024-bc17d680-a14e-11e8-83ff-713531d30f9a.png)
(ignore the fact that the "graph this" is on the incorrect report)