### PR TITLE
 Fixed zendesk widget issue where it would sometimes not show up. Sus…

### DIFF
--- a/suclass/cms/templates/body-post.html
+++ b/suclass/cms/templates/body-post.html
@@ -1,1 +1,14 @@
-<script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=8ca24832-80a4-4e66-ba71-c44c36c96b85"></script>
+## We have to wait to append this script to the page,
+## otherwise there's a chance the zendesk widget does
+## not show up on the page. Most likely, due to a race
+## condition where other elements of the page must load first.
+<script>
+  $(document).ready(function(){
+    setTimeout(function(){
+      var script = document.createElement('script');
+      script.id = 'ze-snippet';
+      script.src = 'https://static.zdassets.com/ekr/snippet.js?key=8ca24832-80a4-4e66-ba71-c44c36c96b85';
+      $('body').append(script);
+    }, 500); // Smallest value that guaranteed zendesk widget to show consistently
+  });
+</script>


### PR DESCRIPTION
Fixed zendesk widget issue where it would sometimes not show up. Suspect the issue had to do with iframe the widget being loaded into was not ready before the zendesk script had finished running. 

To fix this, I replaced the existing script tag with a custom script that adds a manual delay before adding the zendesk script element to the DOM. Some more info here: https://stackoverflow.com/a/13459106

Right now, the delay is set to 1000ms. In my testing, this was the lower limit that reliably allowed the widget to show up. 