### PR TITLE
Add global Stanford footer to all pages in Studio

### DIFF
--- a/lagunita/cms/static/css/vendor/su-identity.css
+++ b/lagunita/cms/static/css/vendor/su-identity.css
@@ -1,0 +1,1 @@
+../../../../lms/static/css/vendor/su-identity.css

--- a/lagunita/cms/static/images/footer-stanford-logo.png
+++ b/lagunita/cms/static/images/footer-stanford-logo.png
@@ -1,0 +1,1 @@
+../../../lms/static/images/footer-stanford-logo.png

--- a/lagunita/cms/templates/body-post.html
+++ b/lagunita/cms/templates/body-post.html
@@ -1,3 +1,4 @@
+## mako
 <%namespace name='static' file='/static_content.html'/>
 <%block name="header_extras">
     <link rel="stylesheet" href="${static.url('css/vendor/su-identity.css')}" />
@@ -5,4 +6,3 @@
 </%block>
 
 <%include file="${static.get_template_path(relative_path='su-footer.html')}"  />
-<script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=8ca24832-80a4-4e66-ba71-c44c36c96b85"></script>

--- a/lagunita/cms/templates/su-footer.html
+++ b/lagunita/cms/templates/su-footer.html
@@ -1,0 +1,1 @@
+../../lms/templates/su-footer.html

--- a/suclass/cms/static/css/vendor/su-identity.css
+++ b/suclass/cms/static/css/vendor/su-identity.css
@@ -1,0 +1,1 @@
+../../../../lms/static/css/vendor/su-identity.css

--- a/suclass/cms/static/images/footer-stanford-logo.png
+++ b/suclass/cms/static/images/footer-stanford-logo.png
@@ -1,0 +1,1 @@
+../../../lms/static/images/footer-stanford-logo.png

--- a/suclass/cms/templates/su-footer.html
+++ b/suclass/cms/templates/su-footer.html
@@ -1,0 +1,1 @@
+../../lms/templates/su-footer.html


### PR DESCRIPTION
This ended up being pretty easy, given the recent-ish addition of the `body-post.html` hook we put in for the ZenDesk widget.

Most everything is just a bunch of symlinks :)

## Before

<img width="1430" alt="screen shot 2019-02-16 at 02 10 00" src="https://user-images.githubusercontent.com/7300975/52898243-56091c00-3190-11e9-803f-2b576954d0bf.png">

## After

<img width="1444" alt="screen shot 2019-02-16 at 02 10 42" src="https://user-images.githubusercontent.com/7300975/52898227-2eb24f00-3190-11e9-92c5-c0bcfbeae163.png">

in Lagunita and SUclass