### PR TITLE
Add global Stanford header to all pages

### DIFF
--- a/lagunita/cms/static/images/header-stanford-logo.png
+++ b/lagunita/cms/static/images/header-stanford-logo.png
@@ -1,0 +1,1 @@
+../../../lms/static/images/header-stanford-logo.png

--- a/lagunita/cms/templates/header_pre.html
+++ b/lagunita/cms/templates/header_pre.html
@@ -1,0 +1,3 @@
+<%namespace name='static' file='/static_content.html'/>
+
+<%include file="${static.get_template_path(relative_path='su-header.html')}" />

--- a/lagunita/cms/templates/su-header.html
+++ b/lagunita/cms/templates/su-header.html
@@ -1,0 +1,1 @@
+../../lms/templates/su-header.html

--- a/suclass/cms/static/images/header-stanford-logo.png
+++ b/suclass/cms/static/images/header-stanford-logo.png
@@ -1,0 +1,1 @@
+../../../lms/static/images/header-stanford-logo.png

--- a/suclass/cms/templates/header_pre.html
+++ b/suclass/cms/templates/header_pre.html
@@ -1,0 +1,1 @@
+../../../lagunita/cms/templates/header_pre.html

--- a/suclass/cms/templates/su-header.html
+++ b/suclass/cms/templates/su-header.html
@@ -1,0 +1,1 @@
+../../../lagunita/cms/templates/su-header.html


### PR DESCRIPTION
Note: This PR assumes that the related Stanford Footer PR has already merged;
this depends on CSS that it adds to all pages.