### PR TITLE
Change account activation message on Dashboard

### DIFF
--- a/lagunita/lms/templates/registration/activate_account_notice.html
+++ b/lagunita/lms/templates/registration/activate_account_notice.html
@@ -1,0 +1,26 @@
+<%page expression_filter="h"/>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<div class="wrapper-msg urgency-high">
+  <div class="msg">
+    <div class="msg-content">
+      <h2 class="title">${_("You're almost there!")}</h2>
+      <div class="copy">
+        <p class='activation-message'>${Text(_(
+          "There's just one more step. We've sent an email message to "
+          "{email_start}{email}{email_end} with "
+          "instructions for activating your account. If "
+          "you don't receive this message, please check your "
+          "spam folder."
+          )).format(
+            email_start=HTML("<strong>"),
+            email_end=HTML("</strong>"),
+            email=email,
+        )}
+        </p>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Change account activation message on Lagunita Dashboard to remove
account activation text. This improves the user experience for auto
enrolled participants.