### PR TITLE
Use old django import for URL reverse

### DIFF
--- a/lagunita/lms/templates/email_change_successful.html
+++ b/lagunita/lms/templates/email_change_successful.html
@@ -1,6 +1,6 @@
 <%inherit file="main.html" />
 <%!
-from django.urls import reverse
+from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 %>
 <section class="container activation">


### PR DESCRIPTION
I'm not sure how I merged this like this...
I remember explicitly encountering this issue, even going as far as
flagging it as "this will need updated in hawthorn" and testing the
change locally...

Anyway...