### PR TITLE
Track Google Analytics tags used for registration

### DIFF
--- a/lagunita/lms/templates/google_analytics.html
+++ b/lagunita/lms/templates/google_analytics.html
@@ -1,3 +1,62 @@
+<%!
+from django.conf import settings
+
+from student.models import RegistrationCookieConfiguration
+%>
+<%
+utm_cookie_enabled = RegistrationCookieConfiguration.current().enabled
+utm_cookie_name = RegistrationCookieConfiguration.current().utm_cookie_name
+utm_cookie_domain = settings.SESSION_COOKIE_DOMAIN or 'localhost'
+%>
+% if utm_cookie_enabled and utm_cookie_name:
+<script type="text/javascript">
+(function () {
+    var iCookieLengthDays = 90; // Cookie length in days
+    var sCookieDomain = "${utm_cookie_domain}";
+    var sCookieName = "${utm_cookie_name}"; // Name of the first party cookie to utilise for last click referrer de-duplication
+    var sSourceParameterName = "utm_source"; // The parameter used by networks and other marketing channels to tell you who drove the traffic
+    var sMediumParameterName = "utm_medium"; // The parameter to identify the type of referrer
+    var sCampaignParameterName = "utm_campaign"; // The parameter to identify the specific effort which drove the traffic
+    var sTermParameterName = "utm_term"; // The parameter to identify the specific keyword which drove the traffic
+    var sContentParameterName = "utm_content"; // The parameter to identify the campaign content.  Useful for differentiating A/B tests
+
+    function _getQueryStringValue(sParameterName) {
+        var aQueryStringPairs = document.location.search.substring(1).split("&");
+        for (var i = 0; i < aQueryStringPairs.length; i++) {
+            var aQueryStringParts = aQueryStringPairs[i].split("=");
+            if (sParameterName.toLowerCase() == aQueryStringParts[0].toLowerCase()) {
+                return aQueryStringParts[1];
+            }
+        }
+    }
+
+    function _setCookie(sCookieName, sCookieContents, iCookieLengthDays) {
+        var dCookieExpires = new Date(),
+            iCookieLengthMilliseconds = iCookieLengthDays * 24 * 60 * 60 * 1000;
+        dCookieExpires.setTime(dCookieExpires.getTime() + iCookieLengthMilliseconds);
+        document.cookie = sCookieName + "=" + sCookieContents + "; expires=" + dCookieExpires.toGMTString() + "; path=/; domain=." + sCookieDomain + ";";
+    }
+
+    var sSourceValue = _getQueryStringValue(sSourceParameterName),
+        sMediumeValue = _getQueryStringValue(sMediumParameterName),
+        sCampaignValue = _getQueryStringValue(sCampaignParameterName),
+        sTermValue = _getQueryStringValue(sTermParameterName),
+        sContentValue = _getQueryStringValue(sContentParameterName);
+
+    if ( sSourceValue || sMediumeValue || sCampaignValue || sTermValue || sContentValue ) {
+        var oCookieContent = {
+            utm_source: sSourceValue,
+            utm_medium: sMediumeValue,
+            utm_campaign: sCampaignValue,
+            utm_term: sTermValue,
+            utm_content: sContentValue,
+            created_at: new Date().getTime()
+        };
+        _setCookie(sCookieName, JSON.stringify(oCookieContent), iCookieLengthDays);
+    }
+}());
+</script>
+% endif
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
Save the most recently-used Google Analtyics parameters and then save
them as a user attribute upon account registration.

Query String Parameters:
- utm_source
- utm_medium
- utm_campaign
- utm_term
- utm_content

This is cribbed from upstream [1].

- [1] https://github.com/edx/ecommerce-scripts/blob/master/gtm_scripts/utm_tracking/stage_utm_cookie.js