### PR TITLE
Split out studio GA code to its own template

### DIFF
--- a/lagunita/cms/templates/head-extra.html
+++ b/lagunita/cms/templates/head-extra.html
@@ -1,11 +1,4 @@
 <%namespace name='static' file='/static_content.html'/>
 <link rel="stylesheet" href="${static.url('css/vendor/su-identity.css')}" />
 <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,700|Source+Sans+Pro:400,400i,600" rel="stylesheet">
-<script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-40837107-2', 'studio.lagunita.stanford.edu', {'allowAnchor': true});
-    ga('send', 'pageview', (location.pathname + location.search + location.hash));
-</script>
+<%static:optional_include_mako file="head-ga.html" />

--- a/lagunita/cms/templates/head-ga.html
+++ b/lagunita/cms/templates/head-ga.html
@@ -1,0 +1,8 @@
+<script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    ga('create', 'UA-40837107-2', 'studio.lagunita.stanford.edu', {'allowAnchor': true});
+    ga('send', 'pageview', (location.pathname + location.search + location.hash));
+</script>


### PR DESCRIPTION
so that we can symlink `head-extra.html` without including
Google Analytics.